### PR TITLE
use stderr instead of stdout for prompts

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -442,7 +442,7 @@ def prompt_4_value(question, choices = None, default = None, display_choices = T
                 print '%3d. %s' % (choices.index(c), c)
         if is_question:
             question = question + '? '
-	sys.stdout.write(question)
+	sys.stderr.write(question)
         choice = raw_input()
         if choices:
             user_choices = [item.strip() for item in choice.split(',')]
@@ -473,7 +473,7 @@ def prompt_4_value(question, choices = None, default = None, display_choices = T
 #
 def prompt_4_yes_no(question):
     while True:
-        sys.stdout.write(question + ' (y/n)? ')
+        sys.stderr.write(question + ' (y/n)? ')
         choice = raw_input().lower()
         if choice == 'yes' or choice == 'y':
             return True


### PR DESCRIPTION
I have a script that checks whether `~/.aws/credentials` is older than some number of seconds, and re-runs the init-sts-session script if so before doing `exec "$@"` as the very last thing.

The point is to be able to run `that_script s3cmd ls` or `that_script aws s3 ls` or whatever other command, and have `that_script` notice that your temporary credential is probably expired by now and prompt you for a new MFA before trying the command.

Because AWSUtils prints to stdout, e.g. `that_script s3cmd ls | sort` gets the MFA prompt mixed in with the s3cmd output.  Use stderr instead so that doesn't happen.